### PR TITLE
added option to set a count for requesting 'stats'| README updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,15 @@
 [![Gem](https://img.shields.io/gem/v/kutt.svg?style=flat)](http://rubygems.org/gems/kutt "I', on RUBYGEMS")
 [![Gem](https://img.shields.io/gem/dt/kutt.svg)](https://rubygems.org/gems/kutt)
 
-ruby library for work with kutt.it
+A Ruby wrapper for kutt.it API
 
 ```
 $ gem install kutt
 ```
 
-for get an apikey go to kutt.it and signup and get an apikey :D
+To get an apikey you need to signup at kutt.it and generate API key from settings.
 
-see what's returned on functions in [here](https://github.com/thedevs-network/kutt#api).
-
-make a new kutt object with apikey (register and get that from https://kutt.it)
+Check API response details at [Official repo](https://github.com/thedevs-network/kutt#api).
 ```ruby
 require 'kutt'
 k = Kutt.new 'apikey'
@@ -21,20 +19,25 @@ k = Kutt.new 'apikey'
 
 submit a new short url:
 ```ruby
-k.submit("url", customurl="customurl", password="password", reuse=true) # customurl, password, reuse are optional | return status code and object as hash or error
+# returns status code and object as hash or error
+# `customurl`, `password`, `reuse` are optional
+# set `reuse = true` to prevent duplicate shortend url for same link
+k.submit("url", customurl="customurl", password="password", reuse=true)
 ```
 
-list all urls:
+list urls (5 by default):
 ```ruby
-k.list # return hash of url list or error
+k.list # returns hash of urls list or error
+
+k.list(20) # to list 20 urls
 ```
 
 delete an url:
 ```ruby
-k.delete("id or url") # return message of success or error
+k.delete("id or url") # returns message of success or error
 ```
 
-stats of an url:
+stats of an specific url:
 ```ruby
-k.stats("id or url") # return message of success or error
+k.stats("id or url") # returns link stats in detail or error
 ```

--- a/lib/kutt.rb
+++ b/lib/kutt.rb
@@ -54,8 +54,8 @@ class Kutt
     return r.code, r.to_hash
   end
   
-  def list()
-    r = HTTParty.get(@base_url+'/api/url/geturls',
+  def list(count = 5)
+    r = HTTParty.get(@base_url+'/api/url/geturlsi?count='+count.to_s,
       :headers => @headers)
     
     return r.code, r.to_hash


### PR DESCRIPTION
Salaam,

I had a problem which i could not get all of my links via `stats()` and it returns first 5 links (default). I have checked their docs and find out there is a `count` parameter. I edited your code to use it and i liked to add this feature to your code so everyone can use it as well. 
Hail to Rubyists! :)

Also i edited some lines of README so i think it looks better now.

Regards,
MohammadReza